### PR TITLE
Make the error creation more ergonomic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "mirror-error"
-version = "0.1.0"
+version = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirror-error"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,9 @@ pub struct MirrorError {
 
 #[allow(dead_code)]
 impl MirrorError {
-    pub fn new(msg: &str) -> MirrorError {
+    pub fn new<S: Into<String>>(msg: S) -> MirrorError {
         MirrorError {
-            details: msg.to_string(),
+            details: msg.into(),
         }
     }
 }
@@ -34,9 +34,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn err_pass() {
-        let err = MirrorError::new(&format!("testing error {}", "123456".to_string()));
+    fn err_pass_str() {
+        let err = MirrorError::new("testing error 123456");
         assert_eq!(err.to_string(), "testing error 123456");
         assert_eq!(err.description(), "testing error 123456");
+    }
+
+    #[test]
+    fn err_pass_string() {
+        let err = MirrorError::new(String::from("testing owned string"));
+        assert_eq!(err.to_string(), "testing owned string");
+        assert_eq!(err.description(), "testing owned string");
     }
 }


### PR DESCRIPTION
By accepting `Into<String>` we make it possible to have any argument that can be converted to `String` thus accepting both owned strings and references. For the common case of specifying an error message via `format!()` the `.into` call allows the reuse of the resource.